### PR TITLE
qa path and directory change

### DIFF
--- a/configure-bigquery/action.yml
+++ b/configure-bigquery/action.yml
@@ -4,6 +4,13 @@ description: Get BigQuery Service Credentials
 runs:
   using: composite
   steps:
+    - name: Checkout Testing Tools Team Dashboard Data repo
+      uses: actions/checkout@v2
+      with:
+        repository: department-of-veterans-affairs/qa-standards-dashboard-data
+        token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+        path: qa-standards-dashboard-data
+        
     - name: Get BigQuery service credentials
       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
       with:

--- a/init-data-repo/action.yml
+++ b/init-data-repo/action.yml
@@ -7,15 +7,15 @@ runs:
     - name: Checkout Testing Tools Team Dashboard Data repo
       uses: actions/checkout@v2
       with:
-        repository: department-of-veterans-affairs/testing-tools-team-dashboard-data
+        repository: department-of-veterans-affairs/qa-standards-dashboard-data
         token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
-        path: testing-tools-team-dashboard-data
+        path: qa-standards-dashboard-data
 
     - name: Get Node version
       id: get-node-version
       shell: bash
       run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      working-directory: testing-tools-team-dashboard-data
+      working-directory: qa-standards-dashboard-data
 
     - name: Setup Node
       uses: actions/setup-node@v3
@@ -28,4 +28,4 @@ runs:
       run: yarn install --frozen-lockfile --prefer-offline --production=false
       env:
         YARN_CACHE_FOLDER: .cache/yarn
-      working-directory: testing-tools-team-dashboard-data
+      working-directory: qa-standards-dashboard-data


### PR DESCRIPTION
This is to ensure proper path is defined post working-directory changes by qa-standards team.

Goes in alignment with the master ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/39265