### PR TITLE
allow checkout branch

### DIFF
--- a/init-data-repo/action.yml
+++ b/init-data-repo/action.yml
@@ -1,6 +1,12 @@
 name: Init Dashboard Data Repo
 description: Check out repo and install dependencies
 
+inputs:
+  branch:
+    description: branch to check out
+    required: false
+    default: ''
+
 runs:
   using: composite
   steps:
@@ -10,6 +16,7 @@ runs:
         repository: department-of-veterans-affairs/qa-standards-dashboard-data
         token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
         path: qa-standards-dashboard-data
+        ref: ${{ inputs.branch }}
 
     - name: Get Node version
       id: get-node-version


### PR DESCRIPTION
This change is intended to allow a branch ref to be passed to this action, for a feature branch to be checked out. It defaults to an empty string, as that matches the way the actual checkout action defaults this as well. An empty string will do it's due diligence to determine whether main or master is the default branch and choose it accordingly. Otherwise, if a value is passed, it will checkout that branch instead.