### PR TITLE
set-output and external action version updates.

### DIFF
--- a/aws-credentials/action.yml
+++ b/aws-credentials/action.yml
@@ -1,5 +1,5 @@
 name: 'platform-release-tools-actions'
-description: 'aws credentials'  
+description: 'aws credentials'
 inputs:
   aws-access-key-id:
     description: aws-access-key-id
@@ -11,9 +11,9 @@ inputs:
 
 runs:
   using: composite
-  steps:  
+  steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}

--- a/configure-bigquery/action.yml
+++ b/configure-bigquery/action.yml
@@ -5,12 +5,12 @@ runs:
   using: composite
   steps:
     - name: Checkout Testing Tools Team Dashboard Data repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: department-of-veterans-affairs/qa-standards-dashboard-data
         token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
         path: qa-standards-dashboard-data
-        
+
     - name: Get BigQuery service credentials
       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
       with:
@@ -18,7 +18,7 @@ runs:
         env_variable_name: BIGQUERY_SERVICE_CREDENTIALS
 
     - name: Setup Cloud SDK
-      uses: google-github-actions/setup-gcloud@v0
+      uses: google-github-actions/setup-gcloud@v0.6.2
       with:
         project_id: vsp-analytics-and-insights
         service_account_key: ${{ env.BIGQUERY_SERVICE_CREDENTIALS }}

--- a/init-data-repo/action.yml
+++ b/init-data-repo/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Checkout Testing Tools Team Dashboard Data repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: department-of-veterans-affairs/qa-standards-dashboard-data
         token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
@@ -21,7 +21,7 @@ runs:
     - name: Get Node version
       id: get-node-version
       shell: bash
-      run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
       working-directory: qa-standards-dashboard-data
 
     - name: Setup Node

--- a/security-check/action.yml
+++ b/security-check/action.yml
@@ -1,6 +1,6 @@
-  
+
 name: 'platform-release-tools-actions'
-description: 'common action security'  
+description: 'common action security'
 inputs:
   key:
     description: keys for actions/cache@v2
@@ -8,7 +8,7 @@ inputs:
     default: ''
 
 runs:
-  using: composite  
+  using: composite
   steps:
     - name: Install dependencies
       uses: ./.github/workflows/install
@@ -24,15 +24,15 @@ runs:
       shell: bash
       run: |
         if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
-          echo ::set-output name=all_changed_files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }})
+          echo "all_changed_files=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }})" >> $GITHUB_OUTPUT
         else
-          echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
+          echo "all_changed_files=$(git diff --name-only origin/master...)" >> $GITHUB_OUTPUT
         fi
 
     - name: Get app entries for changed files
       id: get-changed-apps
       shell: bash
-      run: echo ::set-output name=app_entries::$(node script/github-actions/get-changed-apps.js)
+      run: echo "app_entries=$(node script/github-actions/get-changed-apps.js)" >> $GITHUB_OUTPUT
       env:
         CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
 

--- a/slack-notify/action.yml
+++ b/slack-notify/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
@@ -32,7 +32,7 @@ runs:
         env_variable_name: SLACK_BOT_TOKEN
 
     - name: Notify Slack
-      uses: slackapi/slack-github-action@v1.17.0
+      uses: slackapi/slack-github-action@v1.23.0
       env:
         SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
       with:


### PR DESCRIPTION
Updates to prepare these actions for the move to node 16 and the changes in ::set-output/::set-state in GHA.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/